### PR TITLE
Clarify what _cw and _ccw 

### DIFF
--- a/raw_data/tracks/README.md
+++ b/raw_data/tracks/README.md
@@ -2,6 +2,8 @@
 # Tracks
 ## Track update interval
 Track data is updated 00:01 UTC daily. Actual update time may vary slightly due to the way actions are scheduled.
+## Track Direction
+Tracks have different suffixes: _cw for clockwise, and _ccw or no-sufffix for counterclockwise
 ## Available tracks
 Currently there are **61 tracks** available in the dataset.
 | Image                                                                                                                                        | Name                                     | Release Date           | Numpy Files                                                                                                                                                                                          | Track Length   | Track Width   |


### PR DESCRIPTION
We need to clarify that cw stands for clockwise and ccw for counterclockwise and that if it doesn't have either suffix, that's the legacy naming and is typically counterclockwise.  

I just had to run a 5 minutes training on the console using Vivala Speedway counterclockwise to confirm it was going in the same direction as caecer_gp. 
